### PR TITLE
Add JUnit tests for controllers

### DIFF
--- a/src/test/java/com/example/controller/EstimateControllerTest.java
+++ b/src/test/java/com/example/controller/EstimateControllerTest.java
@@ -1,0 +1,33 @@
+package com.example.controller;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ui.Model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class EstimateControllerTest {
+
+    @InjectMocks
+    private EstimateController estimateController;
+
+    @Mock
+    private Model model;
+
+    @Test
+    public void testViewEstimates() {
+        // Call the method to be tested
+        String viewName = estimateController.viewEstimates(model);
+
+        // Verify the view name
+        assertEquals("estimate/view", viewName);
+
+        // Verify that the "message" attribute was added to the model
+        verify(model).addAttribute("message", "見積書一覧を表示します。");
+    }
+}

--- a/src/test/java/com/example/controller/InvoiceControllerTest.java
+++ b/src/test/java/com/example/controller/InvoiceControllerTest.java
@@ -1,0 +1,33 @@
+package com.example.controller;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ui.Model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class InvoiceControllerTest {
+
+    @InjectMocks
+    private InvoiceController invoiceController;
+
+    @Mock
+    private Model model;
+
+    @Test
+    public void testViewInvoices() {
+        // Call the method to be tested
+        String viewName = invoiceController.viewInvoices(model);
+
+        // Verify the view name
+        assertEquals("invoice/view", viewName);
+
+        // Verify that the "message" attribute was added to the model
+        verify(model).addAttribute("message", "請求書一覧を表示します。");
+    }
+}

--- a/src/test/java/com/example/controller/OrderControllerTest.java
+++ b/src/test/java/com/example/controller/OrderControllerTest.java
@@ -1,0 +1,33 @@
+package com.example.controller;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ui.Model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class OrderControllerTest {
+
+    @InjectMocks
+    private OrderController orderController;
+
+    @Mock
+    private Model model;
+
+    @Test
+    public void testViewOrders() {
+        // Call the method to be tested
+        String viewName = orderController.viewOrders(model);
+
+        // Verify the view name
+        assertEquals("order/view", viewName);
+
+        // Verify that the "message" attribute was added to the model
+        verify(model).addAttribute("message", "注文書一覧を表示します。");
+    }
+}


### PR DESCRIPTION
This commit introduces JUnit test classes for the following controllers:
- EstimateController
- InvoiceController
- OrderController

Each test class verifies that the controller's view method:
- Returns the correct view name.
- Adds the expected "message" attribute to the model.

Mockito was used to mock the Model dependency in each test.