### PR TITLE
見積書一覧画面の仮実装を追加しました。

### DIFF
--- a/src/main/java/com/example/controller/EstimateController.java
+++ b/src/main/java/com/example/controller/EstimateController.java
@@ -1,8 +1,15 @@
 package com.example.controller;
 
+import com.example.entity.Estimate;
+import com.example.form.EstimateSearchForm;
+import com.example.service.EstimateService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+import java.util.List;
 
 /**
  * 見積管理のコントローラークラスです。
@@ -10,16 +17,33 @@ import org.springframework.web.bind.annotation.GetMapping;
 @Controller
 public class EstimateController {
 
+    private final EstimateService estimateService;
+
     /**
-     * 見積書参照画面を表示します。
+     * EstimateControllerのコンストラクタです。
      *
+     * @param estimateService 見積サービス
+     */
+    @Autowired
+    public EstimateController(EstimateService estimateService) {
+        this.estimateService = estimateService;
+    }
+
+    /**
+     * 見積書一覧画面を表示します。
+     * 検索条件に基づいて見積もりを検索し、結果を画面に渡します。
+     *
+     * @param form  検索条件を格納するフォームオブジェクト
      * @param model モデル
-     * @return 見積書参照画面のテンプレート名
+     * @return 見積書一覧画面のテンプレート名
      */
     @GetMapping("/estimate/view")
-    public String viewEstimates(Model model) {
-        // 必要に応じてデータをモデルに追加
-        model.addAttribute("message", "見積書一覧を表示します。");
+    public String viewEstimates(@ModelAttribute EstimateSearchForm form, Model model) {
+        List<Estimate> estimates = estimateService.searchEstimates(form);
+        model.addAttribute("estimates", estimates);
+        model.addAttribute("estimateSearchForm", form);
+        model.addAttribute("screenTitle", "見積書(一覧)"); // 画面タイトルを設定
+        // model.addAttribute("message", "見積書一覧を表示します。"); // この行は不要になるためコメントアウトまたは削除
         return "estimate/view";
     }
 }

--- a/src/main/java/com/example/form/EstimateSearchForm.java
+++ b/src/main/java/com/example/form/EstimateSearchForm.java
@@ -1,0 +1,78 @@
+package com.example.form;
+
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+/**
+ * 見積検索条件を格納するフォームクラスです。
+ */
+@Data
+public class EstimateSearchForm {
+
+    /**
+     * 作成者
+     */
+    private String creator;
+
+    /**
+     * 見積番号年
+     */
+    private String quotationYear;
+
+    /**
+     * 連番
+     */
+    private Integer serialNumber;
+
+    /**
+     * 枝番
+     */
+    private Integer branchNumber;
+
+    /**
+     * 合計金額(円)From
+     */
+    private BigDecimal totalAmountFrom;
+
+    /**
+     * 合計金額(円)To
+     */
+    private BigDecimal totalAmountTo;
+
+    /**
+     * 会社名
+     */
+    private String companyName;
+
+    /**
+     * 受注状況
+     */
+    private String orderStatus;
+
+    /**
+     * 見積日From
+     */
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private Date estimateDateFrom;
+
+    /**
+     * 見積日To
+     */
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private Date estimateDateTo;
+
+    /**
+     * 納入日From
+     */
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private Date deliveryDateFrom;
+
+    /**
+     * 納入日To
+     */
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private Date deliveryDateTo;
+}

--- a/src/main/java/com/example/repository/EstimateRepository.java
+++ b/src/main/java/com/example/repository/EstimateRepository.java
@@ -1,0 +1,15 @@
+package com.example.repository;
+
+import com.example.entity.Estimate;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 見積エンティティのJPAリポジトリインターフェースです。
+ */
+@Repository
+public interface EstimateRepository extends JpaRepository<Estimate, String> {
+    // 今後の開発で、必要に応じて検索メソッドをここに追加します。
+    // 例えば、会社名での検索など:
+    // List<Estimate> findByCompanyNameContaining(String companyName);
+}

--- a/src/main/java/com/example/service/EstimateService.java
+++ b/src/main/java/com/example/service/EstimateService.java
@@ -1,0 +1,68 @@
+package com.example.service;
+
+import com.example.entity.Estimate;
+import com.example.form.EstimateSearchForm;
+import com.example.repository.EstimateRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 見積もりに関するビジネスロジックを提供するサービスクラスです。
+ */
+@Service
+@Transactional
+public class EstimateService {
+
+    private final EstimateRepository estimateRepository;
+
+    /**
+     * EstimateServiceのコンストラクタです。
+     *
+     * @param estimateRepository 見積リポジトリ
+     */
+    @Autowired
+    public EstimateService(EstimateRepository estimateRepository) {
+        this.estimateRepository = estimateRepository;
+    }
+
+    /**
+     * 指定された検索条件に基づいて見積もりを検索します。
+     * 現時点では、このメソッドはすべての見積もりを最大15件まで返します。
+     * TODO: 検索フォームに基づいたフィルタリングロジックを実装します。
+     *
+     * @param form 見積検索フォーム
+     * @return 見積もりエンティティのリスト
+     */
+    public List<Estimate> searchEstimates(EstimateSearchForm form) {
+        // 現時点ではフィルタリングを行わず、全件取得して最初の15件を返す
+        // 将来的にはformの条件で絞り込む
+        return findAllEstimatesLimited();
+    }
+
+    /**
+     * すべての見積もりを取得します。
+     * このメソッドは主に初期表示や、フィルタリングが不要な場合に使用されます。
+     *
+     * @param pageable ページネーション情報
+     * @return 見積もりエンティティのリスト
+     */
+    public List<Estimate> findAllEstimates(Pageable pageable) {
+        return estimateRepository.findAll(pageable).getContent();
+    }
+
+    /**
+     * すべての見積もりをページネーションなしで取得します（最初の15件）。
+     * searchEstimatesから呼び出されることを想定しています。
+     *
+     * @return 見積もりエンティティのリスト (最大15件)
+     */
+    public List<Estimate> findAllEstimatesLimited() {
+        Pageable pageable = PageRequest.of(0, 15); // 最初のページ、15件
+        return estimateRepository.findAll(pageable).getContent();
+    }
+}

--- a/src/main/resources/templates/estimate/view.html
+++ b/src/main/resources/templates/estimate/view.html
@@ -1,16 +1,128 @@
 <!DOCTYPE html>
-<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" lang="ja">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>見積書参照</title>
-    <link rel="stylesheet" th:href="@{/webjars/bootstrap/5.3.0/css/bootstrap.min.css}">
+    <title th:text="${screenTitle}">見積書(一覧)</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
+          rel="stylesheet"
+          integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM"
+          crossorigin="anonymous">
+    <style>
+        .search-criteria-area {
+            background-color: #f8f9fa;
+            padding: 20px;
+            border-radius: 5px;
+            margin-bottom: 30px;
+        }
+        .table th.text-right, .table td.text-right {
+            text-align: right;
+        }
+        .table th.text-left, .table td.text-left {
+            text-align: left;
+        }
+        .table-striped tbody tr:nth-of-type(odd) {
+            background-color: rgba(0,0,0,.05);
+        }
+    </style>
 </head>
 <body>
-    <div class="container mt-5">
-        <h1>見積書参照</h1>
-        <p th:text="${message}"></p>
+<div class="container mt-4">
+    <h1 th:text="${screenTitle}">見積書(一覧)</h1>
+
+    <!-- Search Criteria Area -->
+    <div class="search-criteria-area">
+        <h2>検索条件</h2>
+        <form th:action="@{/estimate/view}" th:object="${estimateSearchForm}" method="get" class="row g-3">
+            <div class="col-md-4">
+                <label for="creator" class="form-label">作成者</label>
+                <input type="text" class="form-control" id="creator" th:field="*{creator}">
+            </div>
+            <div class="col-md-2">
+                <label for="quotationYear" class="form-label">見積番号年</label>
+                <input type="text" class="form-control" id="quotationYear" th:field="*{quotationYear}">
+            </div>
+            <div class="col-md-2">
+                <label for="serialNumber" class="form-label">連番</label>
+                <input type="number" class="form-control" id="serialNumber" th:field="*{serialNumber}">
+            </div>
+            <div class="col-md-2">
+                <label for="branchNumber" class="form-label">枝番</label>
+                <input type="number" class="form-control" id="branchNumber" th:field="*{branchNumber}">
+            </div>
+
+            <div class="col-md-3">
+                <label for="totalAmountFrom" class="form-label">合計金額(円)From</label>
+                <input type="number" class="form-control" id="totalAmountFrom" th:field="*{totalAmountFrom}">
+            </div>
+            <div class="col-md-3">
+                <label for="totalAmountTo" class="form-label">合計金額(円)To</label>
+                <input type="number" class="form-control" id="totalAmountTo" th:field="*{totalAmountTo}">
+            </div>
+            <div class="col-md-4">
+                <label for="companyName" class="form-label">会社名</label>
+                <input type="text" class="form-control" id="companyName" th:field="*{companyName}">
+            </div>
+            <div class="col-md-2">
+                <label for="orderStatus" class="form-label">受注状況</label>
+                <input type="text" class="form-control" id="orderStatus" th:field="*{orderStatus}">
+            </div>
+
+            <div class="col-md-3">
+                <label for="estimateDateFrom" class="form-label">見積日From</label>
+                <input type="date" class="form-control" id="estimateDateFrom" th:field="*{estimateDateFrom}">
+            </div>
+            <div class="col-md-3">
+                <label for="estimateDateTo" class="form-label">見積日To</label>
+                <input type="date" class="form-control" id="estimateDateTo" th:field="*{estimateDateTo}">
+            </div>
+            <div class="col-md-3">
+                <label for="deliveryDateFrom" class="form-label">納入日From</label>
+                <input type="date" class="form-control" id="deliveryDateFrom" th:field="*{deliveryDateFrom}">
+            </div>
+            <div class="col-md-3">
+                <label for="deliveryDateTo" class="form-label">納入日To</label>
+                <input type="date" class="form-control" id="deliveryDateTo" th:field="*{deliveryDateTo}">
+            </div>
+
+            <div class="col-12">
+                <button type="submit" class="btn btn-primary">検索</button>
+            </div>
+        </form>
     </div>
-    <script th:src="@{/webjars/bootstrap/5.3.0/js/bootstrap.bundle.min.js}"></script>
+
+    <!-- Search Results Area -->
+    <h2>検索結果</h2>
+    <table class="table table-striped table-hover">
+        <thead class="table-light">
+        <tr>
+            <th class="text-left">参照</th>
+            <th class="text-left">見積番号</th>
+            <th class="text-left">作成者</th>
+            <th class="text-left">受注状況</th>
+            <th class="text-left">見積日</th>
+            <th class="text-left">会社名</th>
+            <th class="text-right">合計金額(円)</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="estimate : ${estimates}" th:if="${estimates != null and !estimates.isEmpty()}">
+            <td class="text-left"><button type="button" class="btn btn-sm btn-info">参照</button></td>
+            <td class="text-left" th:text="${estimate.estimateId}"></td>
+            <td class="text-left" th:text="${estimate.employeeCode}"></td> <!-- Assuming employeeCode maps to creator -->
+            <td class="text-left" th:text="${estimate.orderStatus}"></td>
+            <td class="text-left" th:text="${#dates.format(estimate.estimateDate, 'yyyy/MM/dd')}"></td>
+            <td class="text-left" th:text="${estimate.companyName}"></td>
+            <td class="text-right" th:text="${#numbers.formatDecimal(estimate.totalAmount, 1, 'COMMA', 0, 'POINT')}"></td>
+        </tr>
+        <tr th:if="${estimates == null or estimates.isEmpty()}">
+            <td colspan="7" class="text-center">表示する見積もり情報がありません。</td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz"
+        crossorigin="anonymous"></script>
 </body>
 </html>


### PR DESCRIPTION
以下の機能を含む見積書一覧画面の初期バージョンを実装しました。

- 検索条件入力フォーム:
  - 作成者, 見積番号年, 連番, 枝番
  - 合計金額(円)From/To
  - 会社名, 受注状況
  - 見積日From/To, 納入日From/To (標準のdate inputを使用)
- 検索結果表示:
  - 最大15件の見積情報をテーブル形式で表示
  - 表示項目: 参照ボタン, 見積番号, 作成者, 受注状況, 見積日(YYYY/MM/DD), 会社名, 合計金額(円, カンマ区切り)
  - 文字列は左寄せ、数値は右寄せ

関連するコンポーネントとして以下を作成・更新しました:
- `EstimateSearchForm`: 検索条件を保持するフォームクラス
- `EstimateRepository`: 見積エンティティのJPAリポジトリ
- `EstimateService`: 見積関連のビジネスロジックを扱うサービスクラス (現在は全件取得を15件に制限)
- `EstimateController`: 画面表示と検索処理の受付を行うコントローラー
- `estimate/view.html`: Thymeleafテンプレートによる画面描画

現時点では、検索条件に基づいた実際の絞り込み処理およびページネーションは未実装です。
DBアクセスはJPAを利用し、HSQLDBをインメモリデータベースとして使用しています。