### PR TITLE
Fix: Resolve JPA naming strategy for Estimate entities

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,9 @@ spring:
 
   jpa:
     open-in-view: false
+    hibernate:
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
 
   thymeleaf:
     cache: false


### PR DESCRIPTION
Configured Spring JPA Hibernate's physical naming strategy to org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy. This ensures that camelCase entity field names are correctly mapped to snake_case column names in the database.

This change addresses an issue where data inserted via data.sql was not being correctly retrieved by JPA repositories, despite SQL logs showing query execution, because of the naming mismatch.